### PR TITLE
Add vendor prefixing with gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var sass = require('gulp-sass');
 var rename = require('gulp-rename');
 var notify = require('gulp-notify');
 var plumber = require('gulp-plumber');
+var autoprefixer = require('gulp-autoprefixer');
 var browserSync = require('browser-sync').create();
 
 gulp.task('sass', function () {
@@ -11,6 +12,10 @@ gulp.task('sass', function () {
         .pipe(plumber({ errorHandler: notify.onError("Error: <%= error.message %>") }))
         .pipe(notify({ message: "Compiling <%= file.relative %>!!", wait: true}))
         .pipe(sass()) 
+        .pipe(autoprefixer({
+            browsers: ['last 2 versions'],
+            cascade: false
+        }))
         .pipe(gulp.dest('dist/'))
         .pipe(sass({ outputStyle: 'compressed' }))
         .pipe(rename({ extname: '.min.css' }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -370,6 +370,20 @@
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
     },
+    "autoprefixer": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.5.1.tgz",
+      "integrity": "sha512-0zXQ6OqbnVaplQKkKTASxHFPMNy6WfrXS5QRDJ4zTDxEBB3r7NPDSK4h9KCyQi1tq0tX5MsN4RdzChVBn2k/aw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "3.2.8",
+        "caniuse-lite": "1.0.30000846",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "6.0.22",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -754,6 +768,16 @@
         "stream-throttle": "0.1.3"
       }
     },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000846",
+        "electron-to-chromium": "1.3.48"
+      }
+    },
     "bs-recipes": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
@@ -810,6 +834,12 @@
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000846",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000846.tgz",
+      "integrity": "sha512-qxUOHr5mTaadWH1ap0ueivHd8x42Bnemcn+JutVr7GWmm2bU4zoBhjuv5QdXgALQnnT626lOQros7cCDf8PwCg==",
+      "dev": true
     },
     "caseless": {
       "version": "0.11.0",
@@ -1292,6 +1322,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.48",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
       "dev": true
     },
     "encodeurl": {
@@ -2735,6 +2771,20 @@
         "tildify": "1.2.0",
         "v8flags": "2.1.1",
         "vinyl-fs": "0.3.14"
+      }
+    },
+    "gulp-autoprefixer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-5.0.0.tgz",
+      "integrity": "sha1-gjfCeKaXdScKHK/n1vEBz81YVUQ=",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "8.5.1",
+        "fancy-log": "1.3.2",
+        "plugin-error": "1.0.1",
+        "postcss": "6.0.22",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-notify": {
@@ -4337,10 +4387,16 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
     "npm": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.0.1.tgz",
-      "integrity": "sha512-N3uW8jeIXIBp5G3Q6Yu3TTN1ss6BUWuDTHk2JkdTUGaUf0AwKdtVs63O5B75C9NNn7y/7tMpkMCE++xpRhjUBw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.1.0.tgz",
+      "integrity": "sha512-e38cCtJ0lEjLXXpc4twEfj8Xw5hDLolc2Py87ueWnUhJfZ8GA/5RVIeD+XbSr1+aVRGsRsdtLdzUNO63PvQJ1w==",
       "requires": {
         "JSONStream": "1.3.2",
         "abbrev": "1.1.1",
@@ -4351,8 +4407,8 @@
         "archy": "1.0.0",
         "bin-links": "1.1.2",
         "bluebird": "3.5.1",
-        "byte-size": "4.0.2",
-        "cacache": "11.0.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.0.2",
         "call-limit": "1.1.0",
         "chownr": "1.0.1",
         "cli-columns": "3.1.2",
@@ -4399,7 +4455,7 @@
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
         "lodash.without": "4.4.0",
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "meant": "1.0.1",
         "mississippi": "3.0.0",
         "mkdirp": "0.5.1",
@@ -4407,10 +4463,10 @@
         "node-gyp": "3.6.2",
         "nopt": "4.0.1",
         "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.0.8",
+        "npm-audit-report": "1.2.1",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.1",
+        "npm-lifecycle": "2.0.3",
         "npm-package-arg": "6.1.0",
         "npm-packlist": "1.1.10",
         "npm-pick-manifest": "2.1.0",
@@ -4422,7 +4478,7 @@
         "once": "1.4.0",
         "opener": "1.4.3",
         "osenv": "0.1.5",
-        "pacote": "8.1.1",
+        "pacote": "8.1.5",
         "path-is-inside": "1.0.2",
         "promise-inflight": "1.0.1",
         "qrcode-terminal": "0.12.0",
@@ -4435,7 +4491,7 @@
         "read-package-tree": "5.2.1",
         "readable-stream": "2.3.6",
         "readdir-scoped-modules": "1.0.2",
-        "request": "2.85.0",
+        "request": "2.86.0",
         "retry": "0.12.0",
         "rimraf": "2.6.2",
         "safe-buffer": "5.1.2",
@@ -4446,7 +4502,7 @@
         "sorted-union-stream": "2.1.3",
         "ssri": "6.0.0",
         "strip-ansi": "4.0.0",
-        "tar": "4.4.2",
+        "tar": "4.4.1",
         "text-table": "0.2.0",
         "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
@@ -4521,11 +4577,11 @@
           "bundled": true
         },
         "byte-size": {
-          "version": "4.0.2",
+          "version": "4.0.3",
           "bundled": true
         },
         "cacache": {
-          "version": "11.0.1",
+          "version": "11.0.2",
           "bundled": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -4533,7 +4589,7 @@
             "figgy-pudding": "3.1.0",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "mississippi": "3.0.0",
             "mkdirp": "0.5.1",
             "move-concurrently": "1.0.1",
@@ -4960,7 +5016,7 @@
             "find-npm-prefix": "1.0.2",
             "graceful-fs": "4.1.11",
             "lock-verify": "2.0.2",
-            "npm-lifecycle": "2.0.1",
+            "npm-lifecycle": "2.0.3",
             "npm-logical-tree": "1.2.1",
             "npm-package-arg": "6.1.0",
             "pacote": "7.6.1",
@@ -4982,7 +5038,7 @@
                 "cacache": "10.0.4",
                 "get-stream": "3.0.0",
                 "glob": "7.1.2",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "make-fetch-happen": "2.6.0",
                 "minimatch": "3.0.4",
                 "mississippi": "3.0.0",
@@ -4999,7 +5055,7 @@
                 "safe-buffer": "5.1.2",
                 "semver": "5.5.0",
                 "ssri": "5.3.0",
-                "tar": "4.4.2",
+                "tar": "4.4.1",
                 "unique-filename": "1.1.0",
                 "which": "1.3.0"
               },
@@ -5012,7 +5068,7 @@
                     "chownr": "1.0.1",
                     "glob": "7.1.2",
                     "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "mississippi": "2.0.0",
                     "mkdirp": "0.5.1",
                     "move-concurrently": "1.0.1",
@@ -5179,7 +5235,7 @@
                     "http-cache-semantics": "3.8.1",
                     "http-proxy-agent": "2.1.0",
                     "https-proxy-agent": "2.2.1",
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "mississippi": "1.3.1",
                     "node-fetch-npm": "2.0.2",
                     "promise-retry": "1.1.1",
@@ -5618,7 +5674,7 @@
               "requires": {
                 "bluebird": "3.5.1",
                 "figgy-pudding": "3.1.0",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "make-fetch-happen": "4.0.1",
                 "npm-package-arg": "6.1.0"
               },
@@ -5628,11 +5684,11 @@
                   "bundled": true,
                   "requires": {
                     "agentkeepalive": "3.4.1",
-                    "cacache": "11.0.1",
+                    "cacache": "11.0.2",
                     "http-cache-semantics": "3.8.1",
                     "http-proxy-agent": "2.1.0",
                     "https-proxy-agent": "2.2.1",
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "mississippi": "3.0.0",
                     "node-fetch-npm": "2.0.2",
                     "promise-retry": "1.1.1",
@@ -6044,7 +6100,7 @@
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
+                            "lru-cache": "4.1.3",
                             "shebang-command": "1.2.0",
                             "which": "1.3.0"
                           },
@@ -6261,7 +6317,7 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6488,7 +6544,7 @@
             "nopt": "3.0.6",
             "npmlog": "4.1.2",
             "osenv": "0.1.5",
-            "request": "2.85.0",
+            "request": "2.86.0",
             "rimraf": "2.6.2",
             "semver": "5.3.0",
             "tar": "2.2.1",
@@ -6597,7 +6653,7 @@
           }
         },
         "npm-audit-report": {
-          "version": "1.0.8",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
             "cli-table2": "0.2.0",
@@ -6622,7 +6678,7 @@
           }
         },
         "npm-lifecycle": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
             "byline": "5.0.0",
@@ -6728,9 +6784,9 @@
                 "agentkeepalive": "3.3.0",
                 "cacache": "10.0.4",
                 "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.2",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
                 "mississippi": "1.3.1",
                 "node-fetch-npm": "2.0.2",
                 "promise-retry": "1.1.1",
@@ -6768,7 +6824,7 @@
                     "chownr": "1.0.1",
                     "glob": "7.1.2",
                     "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "mississippi": "2.0.0",
                     "mkdirp": "0.5.1",
                     "move-concurrently": "1.0.1",
@@ -6927,11 +6983,11 @@
                   "bundled": true
                 },
                 "http-proxy-agent": {
-                  "version": "2.0.0",
+                  "version": "2.1.0",
                   "bundled": true,
                   "requires": {
                     "agent-base": "4.2.0",
-                    "debug": "2.6.9"
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -6957,7 +7013,7 @@
                       }
                     },
                     "debug": {
-                      "version": "2.6.9",
+                      "version": "3.1.0",
                       "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -6972,7 +7028,7 @@
                   }
                 },
                 "https-proxy-agent": {
-                  "version": "2.1.1",
+                  "version": "2.2.1",
                   "bundled": true,
                   "requires": {
                     "agent-base": "4.2.0",
@@ -7275,7 +7331,7 @@
             "npm-package-arg": "6.1.0",
             "npmlog": "4.1.2",
             "once": "1.4.0",
-            "request": "2.85.0",
+            "request": "2.86.0",
             "retry": "0.10.1",
             "safe-buffer": "5.1.2",
             "semver": "5.5.0",
@@ -7317,7 +7373,7 @@
           "requires": {
             "bluebird": "3.5.1",
             "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "make-fetch-happen": "3.0.0",
             "npm-package-arg": "6.1.0",
             "safe-buffer": "5.1.2"
@@ -7336,7 +7392,7 @@
                 "http-cache-semantics": "3.8.1",
                 "http-proxy-agent": "2.1.0",
                 "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "mississippi": "3.0.0",
                 "node-fetch-npm": "2.0.2",
                 "promise-retry": "1.1.1",
@@ -7374,7 +7430,7 @@
                     "chownr": "1.0.1",
                     "glob": "7.1.2",
                     "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "mississippi": "2.0.0",
                     "mkdirp": "0.5.1",
                     "move-concurrently": "1.0.1",
@@ -7874,16 +7930,17 @@
           }
         },
         "pacote": {
-          "version": "8.1.1",
+          "version": "8.1.5",
           "bundled": true,
           "requires": {
             "bluebird": "3.5.1",
-            "cacache": "11.0.1",
+            "cacache": "11.0.2",
             "get-stream": "3.0.0",
             "glob": "7.1.2",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "make-fetch-happen": "4.0.1",
             "minimatch": "3.0.4",
+            "minipass": "2.3.3",
             "mississippi": "3.0.0",
             "mkdirp": "0.5.1",
             "normalize-package-data": "2.4.0",
@@ -7898,7 +7955,7 @@
             "safe-buffer": "5.1.2",
             "semver": "5.5.0",
             "ssri": "6.0.0",
-            "tar": "4.4.2",
+            "tar": "4.4.1",
             "unique-filename": "1.1.0",
             "which": "1.3.0"
           },
@@ -7912,11 +7969,11 @@
               "bundled": true,
               "requires": {
                 "agentkeepalive": "3.4.1",
-                "cacache": "11.0.1",
+                "cacache": "11.0.2",
                 "http-cache-semantics": "3.8.1",
                 "http-proxy-agent": "2.1.0",
                 "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "mississippi": "3.0.0",
                 "node-fetch-npm": "2.0.2",
                 "promise-retry": "1.1.1",
@@ -8053,11 +8110,11 @@
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.21"
+                        "iconv-lite": "0.4.23"
                       },
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.21",
+                          "version": "0.4.23",
                           "bundled": true,
                           "requires": {
                             "safer-buffer": "2.1.2"
@@ -8149,6 +8206,20 @@
                       "bundled": true
                     }
                   }
+                }
+              }
+            },
+            "minipass": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              },
+              "dependencies": {
+                "yallist": {
+                  "version": "3.0.2",
+                  "bundled": true
                 }
               }
             },
@@ -8339,11 +8410,11 @@
           }
         },
         "request": {
-          "version": "2.85.0",
+          "version": "2.86.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
+            "aws4": "1.7.0",
             "caseless": "0.12.0",
             "combined-stream": "1.0.6",
             "extend": "3.0.1",
@@ -8358,9 +8429,8 @@
             "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
@@ -8371,7 +8441,7 @@
               "bundled": true
             },
             "aws4": {
-              "version": "1.6.0",
+              "version": "1.7.0",
               "bundled": true
             },
             "caseless": {
@@ -8646,11 +8716,7 @@
               "bundled": true
             },
             "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
+              "version": "6.5.2",
               "bundled": true
             },
             "tough-cookie": {
@@ -8786,12 +8852,12 @@
           }
         },
         "tar": {
-          "version": "4.4.2",
+          "version": "4.4.1",
           "bundled": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
+            "minipass": "2.3.1",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
             "safe-buffer": "5.1.2",
@@ -8802,11 +8868,11 @@
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "2.3.1"
               }
             },
             "minipass": {
-              "version": "2.2.4",
+              "version": "2.3.1",
               "bundled": true,
               "requires": {
                 "safe-buffer": "5.1.2",
@@ -8817,12 +8883,8 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "2.3.1"
               }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
@@ -8948,7 +9010,7 @@
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
+                            "lru-cache": "4.1.3",
                             "shebang-command": "1.2.0",
                             "which": "1.3.0"
                           },
@@ -9467,6 +9529,12 @@
         "set-blocking": "2.0.0"
       }
     },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -9878,6 +9946,60 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "6.0.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+      "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "source-map": "0.6.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "preserve": {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
   },
   "homepage": "https://github.com/slant-website/breakpoint.css#readme",
   "dependencies": {
-    "npm": "^6.0.1"
+    "npm": "^6.1.0"
   },
   "devDependencies": {
     "browser-sync": "^2.24.4",
     "del": "^3.0.0",
     "gulp": "^3.9.1",
+    "gulp-autoprefixer": "^5.0.0",
     "gulp-notify": "^3.2.0",
     "gulp-plumber": "^1.2.0",
     "gulp-rename": "^1.2.3",


### PR DESCRIPTION
**Description**
Add automatic vendor prefixing in the gulpfile before the css is built. 
You can use this example to test:

```css
body {
    display: grid;
    transition: all .5s;
    user-select: none;
    background: linear-gradient(to bottom, white, black);
}
```

**Related Issue**
https://github.com/maybeweare/breakpoint.css/issues/22