### PR TITLE
Add code styling

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -15,3 +15,18 @@ a {
       color: $secondary-colour;
     }
 }
+
+code {
+    font-size: 80%;
+    font-family: $mono-font;
+    background: $secondary-colour;
+    padding: .3em;
+    white-space: nowrap;
+}
+
+pre {
+    code {
+        display: block;
+        white-space: pre
+    }
+}

--- a/src/breakpoint.scss
+++ b/src/breakpoint.scss
@@ -4,6 +4,5 @@
 @import "_overrides";
 
 @import "_base";
-@import "_code";
 @import "_container";
 @import "_grid";


### PR DESCRIPTION
**Description**
Add styling for code and pre. For now I added this to `_base.scss` as it seemed too short for its own component (open for discussion)

To test, use `<code>` for inline code snippets, and use `<pre>`wrapped around `<code>` for larger code blocks. e.g. —
```html
<code> .block-test </code> color.
<pre>
    <code> 
    &lt;div class=&quot;grid&quot;&gt;
        This is an example &lt;code&gt; .block-test &lt;/code&gt; color.
        &lt;pre&gt;
            &lt;code&gt; 
                gfgg
                    &lt;div class=&quot;grid&quot;&gt;
                        This is an example &lt;code&gt; .block-test &lt;/code&gt; color.
                    &lt;/div&gt;
                    gdg
            &lt;/code&gt;
            &lt;/pre&gt;
        &lt;/div&gt;
    </code>
</pre>
```

**Related Issue**
https://github.com/maybeweare/breakpoint.css/issues/20